### PR TITLE
Add `repositories` section to main project gradle config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,3 +3,7 @@ plugins {
     kotlin("multiplatform") version "1.7.10" apply false
     kotlin("plugin.serialization") version "1.7.10" apply false
 }
+
+repositories {
+    mavenCentral()
+}


### PR DESCRIPTION
`repositories` section was missing from main Gradle config, fresh builds of project were failing.